### PR TITLE
Add top border to first list item in flush list groups

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pico-firstdraft-css",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Pico CSS stylesheets for First Draft projects",
   "repository": {
     "type": "git",

--- a/pico.firstdraft.css
+++ b/pico.firstdraft.css
@@ -159,6 +159,10 @@ body.pico > footer {
   margin-bottom: 0;
 }
 
+.pico article > ul > li:first-child {
+  border-top: 1px solid var(--pico-muted-border-color);
+}
+
 /* List group action items - similar to Bootstrap */
 .pico article > ul > li > a:only-child {
   display: flex;


### PR DESCRIPTION
Add top border to first list item in flush list groups.

Before:

<img width="774" height="261" alt="Screenshot 2025-09-16 at 2 18 28 PM" src="https://github.com/user-attachments/assets/a26c6aa4-987c-47cf-a312-74b148160c95" />


After:

<img width="783" height="270" alt="Screenshot 2025-09-16 at 2 18 10 PM" src="https://github.com/user-attachments/assets/5a267e55-ec0b-41ad-85f7-2d5e2b98029e" />


<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add top border to first list item in flush list groups and update version to 0.0.2.
> 
>   - **CSS Changes**:
>     - Add top border to first list item in flush list groups in `pico.firstdraft.css`.
>   - **Version Update**:
>     - Update version in `package.json` from `0.0.1` to `0.0.2`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=firstdraft%2Fpico.firstdraft.css&utm_source=github&utm_medium=referral)<sup> for c023b495666d15b5dc18ce325fb93e611bf8ba48. You can [customize](https://app.ellipsis.dev/firstdraft/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->